### PR TITLE
Use new Minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.0] - 2020-01-10
+
 ## [1.2.2] - 2019-10-09
 
 ## [3.0.1-beta] - 2019-04-08

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,11 @@
     "vtex.sandbox": "0.x",
     "vtex.store-drawer": "0.x",
     "vtex.breadcrumb": "1.x",
-    "vtex.telemarketing": "2.x"
+    "vtex.telemarketing": "2.x",
+    "vtex.checkout-summary": "0.x",
+    "vtex.product-list": "0.x",
+    "vtex.add-to-cart-button": "0.x",
+    "vtex.product-specification-badges": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "gc-jqu0734",
   "name": "madinejeans-theme",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "title": "Madine Jeans Theme",
   "builders": {
     "styles": "1.x",

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -158,7 +158,7 @@
       "search-bar",
       "header-spacer",
       "login",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -346,20 +346,37 @@
       "showPasswordVerificationIntoTooltip": true
     }
   },
-  "minicart": {
-    "blocks": [
-      "product-summary"
-    ],
+
+  "minicart.v2": {
+    "children": ["minicart-base-content"]
+  },
+  "minicart-base-content": {
+    "blocks": ["minicart-product-list", "minicart-summary", "minicart-empty-state"]
+  },
+  "minicart-product-list": {
+    "blocks": ["product-list"]
+  },
+  "minicart-summary": {
+    "blocks": ["checkout-summary.compact"]
+  },
+  "checkout-summary.compact": {
+    "children": ["summary-totalizers#minicart"],
     "props": {
-      "type": "popup",
-      "showRemoveButton": true,
-      "showDiscount": true,
-      "showSku": true,
-      "labelMiniCartEmpty": "",
-      "labelButtonFinishShopping": "Finalizar compra",
-      "enableQuantitySelector": true,
-      "maxQuantity": 10,
-      "labelClasses": "gray"
+      "totalizersToShow": ["Items", "Discounts"]
+    }
+  },
+  "summary-totalizers#minicart": {
+    "props": {
+      "showTotal": true,
+      "showDeliveryTotal": false
+    }
+  },
+  "minicart-empty-state": {
+    "children": ["rich-text#empty-state"]
+  },
+  "rich-text#empty-state": {
+    "props": {
+      "text": "Seu carrinho está vazio!"
     }
   },
 
@@ -375,7 +392,7 @@
       "logo",
       "header-spacer",
       "login",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -1113,24 +1130,106 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
   "store.product": {
-    "blocks": [
-      "product-details#default",
-      "product-kit",
+    "children": [
+      "flex-layout.row#product-breadcrumb",
+      "flex-layout.row#product-main",
+      "flex-layout.row#description",
       "shelf.relatedProducts"
     ]
+  },
+  "flex-layout.col#product-image": {
+    "children": ["flex-layout.row#product-image"]
+  },
+  "flex-layout.row#product-breadcrumb": {
+    "props": {
+      "marginTop": 4
+    },
+    "children": ["breadcrumb"]
+  },
+  "flex-layout.row#description": {
+    "props": {
+      "marginBottom": 7
+    },
+    "children": ["product-description"]
+  },
+  "flex-layout.row#product-main": {
+    "props": {
+      "colGap": 7,
+      "rowGap": 7,
+      "marginTop": 4,
+      "marginBottom": 7,
+      "paddingTop": 7,
+      "paddingBottom": 7
+    },
+    "children": ["flex-layout.col#product-image", "flex-layout.col#right-col"]
+  },
+
+  "product-specification-badges": {
+    "props": {
+      "specificationGroupName": "Group",
+      "specificationName": "On Sale",
+      "visibleWhen": "True",
+      "displayValue": "SPECIFICATION_NAME"
+    }
+  },
+
+  "flex-layout.row#product-image": {
+    "children": ["product-images"]
+  },
+  "product-images": {
+    "props": {
+      "displayThumbnailsArrows": true
+    }
+  },
+  "flex-layout.col#right-col": {
+    "props": {
+      "preventVerticalStretch": true,
+      "rowGap": 0
+    },
+    "children": [
+      "vtex.store-components:product-name",
+      "product-price#product-details",
+      "product-separator",
+      "sku-selector",
+      "flex-layout.row#buy-button",
+      "availability-subscriber",
+      "shipping-simulator",
+      "share#default"
+    ]
+  },
+
+  "sku-selector": {
+    "props": {
+      "variationsSpacing": 3,
+      "showValueNameForImageVariation": true
+    }
+  },
+
+  "product-price#product-details": {
+    "props": {
+      "showInstallments": true,
+      "showSavings": true
+    }
+  },
+
+  "flex-layout.row#buy-button": {
+    "props": {
+      "marginTop": 4,
+      "marginBottom": 7
+    },
+    "children": ["add-to-cart-button"]
+  },
+
+  "share#default": {
+    "props": {
+      "social": {
+        "Facebook": true,
+        "WhatsApp": true,
+        "Twitter": false,
+        "Pinterest": true
+      }
+    }
   },
 
 
@@ -1254,46 +1353,10 @@
 
 
 
-  "product-details#default": {
-    "blocks": [
-      "breadcrumb",
-      "product-name",
-      "product-images",
-      "product-price",
-      "product-description",
-      "product-specifications",
-      "buy-button",
-      "sku-selector",
-      "shipping-simulator",
-      "availability-subscriber",
-      "share"
-    ],
+  "add-to-cart-button": {
     "props": {
-      "displayVertically": true,
-      "share": {
-        "social": {
-          "Facebook": true,
-          "WhatsApp": true,
-          "Twitter": false
-        }
-      },
-      "price": {
-        "labelSellingPrice": null,
-        "showListPrice": true,
-        "showLabels": true,
-        "showInstallments": true,
-        "showSavings": true
-      },
-      "name": {
-        "showBrandName": false,
-        "showSku": false,
-        "showProductReference": false
-      }
-    }
-  },
-  "buy-button": {
-    "props": {
-      "isOneClickBuy": true
+      "isOneClickBuy": true,
+      "customOneClickBuyLink": "/cart"
     }
   },
   "search-result": {

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -347,39 +347,6 @@
     }
   },
 
-  "minicart.v2": {
-    "children": ["minicart-base-content"]
-  },
-  "minicart-base-content": {
-    "blocks": ["minicart-product-list", "minicart-summary", "minicart-empty-state"]
-  },
-  "minicart-product-list": {
-    "blocks": ["product-list"]
-  },
-  "minicart-summary": {
-    "blocks": ["checkout-summary.compact"]
-  },
-  "checkout-summary.compact": {
-    "children": ["summary-totalizers#minicart"],
-    "props": {
-      "totalizersToShow": ["Items", "Discounts"]
-    }
-  },
-  "summary-totalizers#minicart": {
-    "props": {
-      "showTotal": true,
-      "showDeliveryTotal": false
-    }
-  },
-  "minicart-empty-state": {
-    "children": ["rich-text#empty-state"]
-  },
-  "rich-text#empty-state": {
-    "props": {
-      "text": "Seu carrinho está vazio!"
-    }
-  },
-
   "header-layout.mobile": {
     "children": [
       "header-row#1-mobile",

--- a/store/blocks/minicart.json
+++ b/store/blocks/minicart.json
@@ -1,0 +1,34 @@
+{
+  "minicart.v2": {
+    "children": ["minicart-base-content"]
+  },
+  "minicart-base-content": {
+    "blocks": ["minicart-product-list", "minicart-summary", "minicart-empty-state"]
+  },
+  "minicart-product-list": {
+    "blocks": ["product-list"]
+  },
+  "minicart-summary": {
+    "blocks": ["checkout-summary.compact"]
+  },
+  "checkout-summary.compact": {
+    "children": ["summary-totalizers#minicart"],
+    "props": {
+      "totalizersToShow": ["Items", "Discounts"]
+    }
+  },
+  "summary-totalizers#minicart": {
+    "props": {
+      "showTotal": true,
+      "showDeliveryTotal": false
+    }
+  },
+  "minicart-empty-state": {
+    "children": ["rich-text#empty-state"]
+  },
+  "rich-text#empty-state": {
+    "props": {
+      "text": "Seu carrinho está vazio!"
+    }
+  }
+}

--- a/store/blocks/product-list.json
+++ b/store/blocks/product-list.json
@@ -1,0 +1,57 @@
+{
+  "product-list": {
+    "blocks": [
+      "product-list-content-desktop",
+      "product-list-content-mobile"
+    ]
+  },
+  "product-list-content-mobile": {
+    "children": ["flex-layout.row#list-row.mobile"]
+  },
+  "flex-layout.row#list-row.mobile": {
+    "children": [
+      "flex-layout.col#image.mobile",
+      "flex-layout.col#main-container.mobile"
+    ],
+    "props": {
+      "fullWidth": true,
+      "paddingBottom": "6",
+      "paddingTop": "5",
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#main-container.mobile": {
+    "children": [
+      "flex-layout.row#top.mobile",
+      "flex-layout.row#quantity-selector.mobile",
+      "flex-layout.row#unit-price.mobile",
+      "flex-layout.row#price.mobile",
+      "flex-layout.row#message.mobile"
+    ],
+    "props": {
+      "width": "grow"
+    }
+  },
+  "flex-layout.row#top.mobile": {
+    "children": [
+      "flex-layout.col#product-description",
+      "flex-layout.col#remove-button.mobile"
+    ],
+    "props": {
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#product-description": {
+    "children": [
+      "flex-layout.row#product-name",
+      "flex-layout.row#product-variations"
+    ],
+    "props": {
+      "marginBottom": "5",
+      "width": "grow",
+      "preventVerticalStretch": "true"
+    }
+  }
+}


### PR DESCRIPTION
We recently started using the new Cart in some GoCommerce stores (Madine being one of them), but it doesn't work well with the current Minicart. Since both components use different data sources, the UI becomes inconsistent if the user interacts with the product list in the `/cart` page.

This PR fixes this issue by replacing the Minicart with a newer version, that uses the same architecture that the new Cart uses. This ensures both the product list and the Minicart display always the same information.

In order to do this change, it was necessary to replace the `product.details` block in the theme with a `flex-layout` structure, which is also used in the `store-theme`. This resulted in a slight change in the UI, which is shown in the screenshots below.

Test workspace: https://marcos--gc-jqu0734.mygocommerce.com/

New minicart: 

| New | ![image](https://user-images.githubusercontent.com/8902498/72161209-704a7a80-339e-11ea-92e4-80e0c1c90436.png) |
|------|------------------|
| **Old** | ![image](https://user-images.githubusercontent.com/8902498/72107400-fd92be00-330f-11ea-9ace-a3b42cbfae03.png) |


Product page:

| New | ![image](https://user-images.githubusercontent.com/8902498/72100431-632b7e00-3301-11ea-9ba4-a65f4690895a.png) |
|------|------------------|
| **Old** | ![image](https://user-images.githubusercontent.com/8902498/72100498-80f8e300-3301-11ea-9b62-f713e8cd48f4.png) |